### PR TITLE
h=0 does not mean black

### DIFF
--- a/altcolor/hsla.go
+++ b/altcolor/hsla.go
@@ -25,9 +25,7 @@ func (col HSLA) RGBA() (red, green, blue, alpha uint32) {
 	x := c * (1 - math.Abs(math.Mod(hdash,2) - 1))
 
 	var r, g, b float64
-	if h == 0 {
-		r = 0; g = 0; b = 0
-	} else if hdash < 1 {
+	if hdash < 1 {
 		r = c; g = x; b = 0
 	} else if hdash < 2 {
 		r = x; g = c; b = 0

--- a/altcolor/hsva.go
+++ b/altcolor/hsva.go
@@ -24,9 +24,7 @@ func (col HSVA) RGBA() (red, green, blue, alpha uint32) {
 	x := c * (1 - math.Abs(math.Mod(hdash,2) - 1))
 
 	var r, g, b float64
-	if h == 0 {
-		r = 0; g = 0; b = 0
-	} else if hdash < 1 {
+	if hdash < 1 {
 		r = c; g = x; b = 0
 	} else if hdash < 2 {
 		r = x; g = c; b = 0


### PR DESCRIPTION
The implementation of HSLA and HSVA have a small bug where the returned called is black if h == 0, independent of the remaining parameters.

I fixed this, but I did not check for negative h, because I didn't know how you want to handle that :)
